### PR TITLE
Web 4678

### DIFF
--- a/example/config.yml
+++ b/example/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: github
-  repo: celartem/extensis-cms
+  repo: aponder-celartem/verbose-bassoon
 
 publish_mode: editorial_workflow
 

--- a/example/config.yml
+++ b/example/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: github
-  repo: aponder-celartem/verbose-bassoon
+  repo: celartem/extensis-cms
 
 publish_mode: editorial_workflow
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extinguisher",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Fork of NetlifyCMS with a customized editorial workflow for Extensis",
   "main": "dist/cms.js",
   "scripts": {

--- a/src/components/Workflow/WorkflowCard.css
+++ b/src/components/Workflow/WorkflowCard.css
@@ -62,7 +62,8 @@
 }
 
 .nc-workflow-card-buttonDelete,
-.nc-workflow-card-buttonPublish {
+.nc-workflow-card-buttonPublish,
+.nc-workflow-card-buttonPreview {
   width: auto;
   flex: 1 0 0;
   font-size: 13px;
@@ -79,9 +80,14 @@
   background-color: var(--colorTeal);
   color: var(--colorTextLight);
   margin-left: 6px;
+  margin-right: 6px;
 }
 
 .nc-workflow-card-buttonPublishDisabled {
   background-color: var(--colorGrayLight);
   color: var(--colorGray);
+}
+
+.nc-workflow-card-buttonPreview {
+  margin-left: 6px;
 }

--- a/src/components/Workflow/WorkflowCard.js
+++ b/src/components/Workflow/WorkflowCard.js
@@ -16,6 +16,7 @@ const WorkflowCard = ({
   onDelete,
   canPublish,
   onPublish,
+  getPreview
 }) => (
   <div className="nc-workflow-card">
     <Link to={editLink} className="nc-workflow-link">
@@ -35,6 +36,9 @@ const WorkflowCard = ({
         onClick={onPublish}
       >
         {isModification ? 'Publish changes' : 'Publish new entry'}
+      </button>
+      <button className="nc-workflow-card-buttonPreview" onClick={getPreview}>
+        Deploy Preview
       </button>
     </div>
   </div>

--- a/src/components/Workflow/WorkflowList.js
+++ b/src/components/Workflow/WorkflowList.js
@@ -35,6 +35,10 @@ class WorkflowList extends React.Component {
     handleDelete: PropTypes.func.isRequired,
   };
 
+  getDeployPreview = (previewUrl) => {
+    window.open(previewUrl);
+  };
+
   handleChangeStatus = (newStatus, dragProps) => {
     const slug = dragProps.slug;
     const collection = dragProps.collection;
@@ -101,6 +105,7 @@ Please drag the card to the "Ready" column to enable publishing.`
             const collection = entry.getIn(['metaData', 'collection']);
             const isModification = entry.get('isModification');
             const canPublish = ownStatus === status.last() && !entry.get('isPersisting', false);
+            const previewUrl = entry.getIn(['metaData', 'pr', 'target_url']);
             return (
               <DragSource
                 namespace={DNDNamespace}
@@ -123,6 +128,7 @@ Please drag the card to the "Ready" column to enable publishing.`
                     onDelete={this.requestDelete.bind(this, collection, slug, ownStatus)}
                     canPublish={canPublish}
                     onPublish={this.requestPublish.bind(this, collection, slug, ownStatus)}
+                    getPreview={this.getDeployPreview.bind(this, previewUrl)}
                   />
                 </div>
               )}


### PR DESCRIPTION
**- Summary**
Adding a Deploy Preview button in the editorial workflow that uses the target_url from the commit status. If the commit status is still in a state of pending, retry until it is no longer pending. Note that this does increase the length of time that it takes from clicking Save to being able to navigate or make more changes, because we have to wait for the build to complete. We will probably want to enhance this feature soon.

**- Test plan**
Create a new blog post, then save it. Wait for the save to complete. Navigate to the editorial workflow. Click the Deploy Preview button.

**- Description for the changelog**
adding a Deploy Preview button in the editorial workflow
